### PR TITLE
constructor of ExporterService is changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The XLD XL Deploy plugin is a XL Deploy plugin that adds capabilities to "deploy
 ## Requirements
 
 * **XL Deploy requirements**
-	* **XL Deploy**: version 4.0+
+	* **XL Deploy**: version 9.0+
 	* **Other XL Deploy Plugins**: None
 	* Apache HTTP Client mime jar version 4.2.1 (to match the http libraries already available in XL Deploy)
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ xlDocker {
     runPortMapping = '14516:4516'
 }
 
-version="6.0.0"
-def apiVersion = '2017.5.0'
+version="7.0.0"
+def apiVersion = '2019.3.4'
 
 repositories {
     mavenLocal()

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ xlDocker {
 }
 
 version="7.0.0"
-def apiVersion = '2019.3.4'
+def apiVersion = '2019.3.11'
 
 repositories {
     mavenLocal()
@@ -31,8 +31,8 @@ repositories {
 
 dependencies {
     compile "com.xebialabs.deployit:udm-plugin-api:$apiVersion"
-    compile "org.apache.httpcomponents:httpmime:4.5.2"
-    distBundle "org.apache.httpcomponents:httpmime:4.5.2"
+    compile "org.apache.httpcomponents:httpmime:4.5.13"
+    distBundle "org.apache.httpcomponents:httpmime:4.5.13"
 }
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip

--- a/src/main/resources/xldeploy/export_dar.py
+++ b/src/main/resources/xldeploy/export_dar.py
@@ -8,6 +8,7 @@ from com.xebialabs.deployit.plugin.api.flow import StepExitCode
 from com.xebialabs.deployit.repository import RepositoryServiceHolder
 from com.xebialabs.deployit.repository import WorkDir
 from com.xebialabs.deployit.service.version.exporter import ExporterService
+from com.xebialabs.deployit.checksum import Sha256ChecksumProvider
 from com.xebialabs.overthere.local import LocalConnection
 from com.xebialabs.overthere.local import LocalFile
 from ext.deployit.plugin.xldeploy import PushToServer
@@ -46,7 +47,8 @@ package_id = get_parent_id(bundle_id)
 context.logOutput("Exporting: %s\n" % package_id)
 local_connection = LocalConnection.getLocalConnection()
 repository_service = RepositoryServiceHolder.getRepositoryService()
-export_service = ExporterService(repository_service)
+checksum_provider = Sha256ChecksumProvider()
+export_service = ExporterService(repository_service, checksum_provider)
 
 try:
     working_directory = local_connection.getWorkingDirectory()


### PR DESCRIPTION
De ExporterService for xld > 9.0 has a new constructor with a check sum
provider as extra parameter

This plugin is not compatible with xldeploy version 9.5.4.

The signature of the constructor of com.xebialabs.deployit.service.version.exporter.ExporterService has changed.

This reported in issue https://support.digital.ai/hc/en-us/requests/132715 

I have made a patch in a PR but don't know how to change the build tools to a more current version.
